### PR TITLE
Minor syntax error

### DIFF
--- a/sampyl/samplers/slice.py
+++ b/sampyl/samplers/slice.py
@@ -71,7 +71,7 @@ class Slice(Sampler):
         if self.compwise:
             ordering = range(dims)
             np.random.shuffle(ordering)
-            new_x = self.state.tovector.copy()
+            new_x = self.state.tovector().copy()
             for d in ordering:
                 direction    = np.zeros((dims))
                 direction[d] = 1.0


### PR DESCRIPTION
It seems that there is a syntax error in sampler.slice.py

Sampler.slice.py : line 74 tovector.copy() => tovector().copy()