### PR TITLE
Ad hoc bug fix that would make examples from the docs work

### DIFF
--- a/examples/tank.py
+++ b/examples/tank.py
@@ -1,0 +1,39 @@
+"""
+German tank problem from
+http://matatat.org/sampyl/examples/german_tank_problem.html
+"""
+
+import sampyl as smp
+from sampyl import np
+import matplotlib
+matplotlib.use('TkAgg')
+import matplotlib.pyplot as plt
+
+# Data
+serials = np.array([10, 256, 202, 97])
+m = np.max(serials)
+
+# log P(N | D)
+def logp(N):
+    # Samplers will pass in floats, we need to make them integers
+    N = np.floor(N).astype(int)
+
+    # Log-likelihood
+    llh = smp.discrete_uniform(serials, lower=1, upper=N)
+
+    prior = smp.discrete_uniform(N, lower=m, upper=10000)
+
+    return llh + prior
+
+# Slice sampler for drawing from the posterior
+sampler = smp.Slice(logp, {'N':300})
+chain = sampler.sample(20000, burn=4000, thin=4)
+
+posterior = np.floor(chain.N)
+plt.hist(posterior, range=(0, 1000), bins=100,
+         histtype='stepfilled', normed=True)
+plt.xlabel("Total number of tanks")
+plt.ylabel("Posterior probability mass")
+
+plt.show()
+pass

--- a/examples/test.py
+++ b/examples/test.py
@@ -1,0 +1,74 @@
+import sampyl as smp
+from sampyl import np
+import matplotlib
+matplotlib.use('TkAgg')
+import matplotlib.pyplot as plt
+# import seaborn as sns
+N = 200
+
+# True parameters
+sigma = 1
+true_b = np.array([2, 1, 4])
+
+# Features, including a constant
+X = np.ones((N, len(true_b)))
+X[:,1:] = np.random.rand(N, len(true_b)-1)
+
+# Outcomes
+y = np.dot(X, true_b) + np.random.randn(N)*sigma
+pass
+
+plt.plot(y,X[:,1],'r.')
+plt.plot(y,X[:,2],'g.')
+
+# Here, b is a length 3 array of coefficients
+def logp(b, sig):
+    if smp.outofbounds(sig > 0):
+        return -np.inf
+
+    # Predicted value
+    y_hat = np.dot(X, b)
+
+    # Log-likelihood
+    llh = smp.normal(y, mu=y_hat, sig=sig)
+
+    # log-priors
+    prior_sig = smp.exponential(sig)
+    prior_b = smp.normal(b, mu=0, sig=100)
+
+    return llh + prior_sig + prior_b
+
+start = smp.find_MAP(logp, {'b': np.ones(3), 'sig': 1.})
+
+nuts = smp.NUTS(logp, start)
+chain = nuts.sample(2100, burn=100)
+
+plt.ion()
+plt.subplots()
+for i in range(3):
+    plt.hist(chain.b[:,i])
+plt.show()
+
+# slice traces
+plt.subplots()
+plt.plot(chain.b)
+plt.show()
+pass
+
+slice = smp.Slice(logp,start)
+trace = slice.sample(2100)
+
+# histogram for SLice results
+plt.subplots()
+for i in range(3):
+    plt.hist(trace.b[:,i])
+plt.show()
+
+# slice traces
+plt.subplots()
+plt.plot(trace.b)
+plt.show()
+
+
+pass
+

--- a/sampyl/samplers/base.py
+++ b/sampyl/samplers/base.py
@@ -117,7 +117,7 @@ class Sampler(object):
 
         start_time = time.time() # For progress bar
         for i in range(num):
-            samples[i] = next(self.sampler).tovector()
+            samples[i] = tuple(next(self.sampler).values())
 
             if progress_bar and time.time() - start_time > 1:
                 update_progress(i+1, num)


### PR DESCRIPTION
On-line bug fix in base.py that makes examples from
http://matatat.org/sampyl/tutorial.html
and
http://matatat.org/sampyl/examples/german_tank_problem.html
work. Example code added to examples folder, running requires matplotlib